### PR TITLE
Catch null pointers if material not found from NistManager

### DIFF
--- a/g4ppyy/builder/__init__.py
+++ b/g4ppyy/builder/__init__.py
@@ -332,9 +332,12 @@ def build_logical(name : str,
         solid = build_solid(name, solid, x, y, z, rmin, rmax, phimin, phimax, thetamin, thetamax)
 
     if isinstance(material, str):
-        material = build_material(material)
+        built_material = build_material(material)
 
-    log = _lzl.G4LogicalVolume(solid, material, name)
+    if not built_material:
+        raise ValueError(f"Could not build material: {material}")
+    
+    log = _lzl.G4LogicalVolume(solid, built_material, name)
     gLogicalList.append(log)
 
     # Move to overriding drawstyles.        


### PR DESCRIPTION
If you make a mistake with the material name when using `build_component` i.e. `G4_GALACTIC` rather than `G4_Galactic` then it will fail with a confusing cppyy error because the material argument will be given to the logical volume constructor as a null pointer. This PR will raise a ValueError if no material is retrieved from the NistManager before attempting to construct the logical volume.