### PR TITLE
Fix material properties not being set correctly in build_material

### DIFF
--- a/g4ppyy/builder/__init__.py
+++ b/g4ppyy/builder/__init__.py
@@ -95,7 +95,7 @@ def update_table_properties(table, properties):
             xv = properties[key+"_X"]
             yv = properties[key+"_Y"]
 
-            yv = [x for _, x in sorted(zip(yv, xv))]
+            yv = [x for x, _ in sorted(zip(yv, xv))]
             xv = [x for _, x in sorted(zip(xv, xv))]
 
             table.AddProperty(key, 


### PR DESCRIPTION
It seems like the x and y values for a material property (e.g. RINDEX) get set to the same value when using the build_material helper function. This didn't happen in older versions of g4ppyy so must have slipped in during the rewrite